### PR TITLE
Replace realpath command with a python command

### DIFF
--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -142,12 +142,6 @@ check_dependencies() {
         log_error "xattr package not installed" 5
     fi
     ;;
-  Darwin)
-    if ! command -v xattr &> /dev/null
-    then
-        log_error "xattr package not installed" 5
-    fi
-    ;;
   *)
     log_error "$MACHINE is not supported" 3
     ;;

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -100,7 +100,6 @@ check_os(){
     Linux)
       ;;
     Darwin)
-      MACHINE="MacOS"
       ;;
     *)
       log_error "$MACHINE is not supported" 3
@@ -136,6 +135,12 @@ check_dependencies() {
     fi
     log_debug "attr package is installed"
 
+    ;;
+  Darwin)
+    if ! command -v xattr &> /dev/null
+    then
+        log_error "xattr package not installed" 5
+    fi
     ;;
   Darwin)
     if ! command -v xattr &> /dev/null
@@ -372,7 +377,7 @@ file_ignore_status () {
   Linux)
     FILE_ATTR_VALUE="$(getfattr --absolute-names --only-values -m "$FILE_ATTR_NAME" "$1")"
     ;;
-  MacOS)
+  Darwin)
     FILE_ATTR_VALUE="$(xattr -p "$FILE_ATTR_NAME" "$1" 2> /dev/null)"
     ;;
   esac
@@ -396,7 +401,7 @@ ignore_file () {
         attr -s "$FILE_ATTR_NAME" -V 1 "$1" > /dev/null
         (( TOTAL_N_IGNORED_FILES++ ))
         ;;
-      MacOS)
+      Darwin)
         xattr -w "$FILE_ATTR_NAME" 1 "$1" > /dev/null
         (( TOTAL_N_IGNORED_FILES++ ))
         ;;
@@ -495,7 +500,7 @@ revert_ignored (){
       Linux)
         attr -r "$FILE_ATTR_NAME" "$1" > /dev/null
         ;;
-      MacOS)
+      Darwin)
         xattr -d "$FILE_ATTR_NAME" "$1" > /dev/null
     esac
 

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -6,7 +6,7 @@
 IFS='
 '
 set -f
-VERSION=v0.1.4-beta
+VERSION=v0.1.5-beta
 DROPBOX_IGNORE_FILE_NAME=".dropboxignore"
 GIT_IGNORE_FILE_NAME=".gitignore"
 MACHINE="$(uname -s)"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,11 +4,23 @@ Below you will all the available installation options. dropboxignore is currentl
 
 ## Basic Installation
 
-| Mathod | Command                                                                                                       |
-|--------|---------------------------------------------------------------------------------------------------------------|
-| curl   | `sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`  |
-| wget   | `sudo sh -c "$(wget -qO- https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`   |
-| fetch  | `sudo sh -c "$(fetch -o - https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`  |
+=== "cURL"
+
+    ```shell
+    sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"
+    ```
+
+=== "Wget"
+
+    ```shell
+    sudo sh -c "$(wget -qO- https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"
+    ```
+
+=== "fetch"
+
+    ```
+    sudo sh -c "$(fetch -o - https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"
+    ```
 
 ## Snap Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ theme:
 
 markdown_extensions:
   - admonition
+  - pymdownx.keys
+  - pymdownx.superfences
+  - pymdownx.tabbed
 
 repo_url: https://github.com/sp1thas/dropboxignore/
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -99,8 +99,10 @@ teardown () { rm -rf "$TEST_FOLDER"; }
   mkdir "$TEST_FOLDER/f"
   touch "$TEST_FOLDER/f/$GITIGNORE_NAME"
   find_gitignore_files "$TEST_FOLDER"
-  assert_equal "$TEST_FOLDER/f/$GITIGNORE_NAME
-$TEST_FOLDER/$GITIGNORE_NAME" "$GITIGNORE_FILES"
+  run echo "$GITIGNORE_FILES"
+  assert_output --partial "$TEST_FOLDER/f/$GITIGNORE_NAME"
+  run echo "$GITIGNORE_FILES"
+  assert_output --partial "$TEST_FOLDER/$GITIGNORE_NAME"
   # Test file with max depth
   find_gitignore_files "$TEST_FOLDER/$GITIGNORE_NAME"
   assert_equal "$TEST_FOLDER/$GITIGNORE_NAME" "$GITIGNORE_FILES"


### PR DESCRIPTION
The purpose of this PR is to replace `realpath` command with a python command. It looks like `realpath` is not a cross platform  command and is missing from some Operating systems (I.e: Mac Mini M1 2020 #10 ).

@andrevenancio before I merge this PR, please re-install dropboxignore using `fix-missing-realpath-command` branch in order to verify that issue has been resolved. Thanks in advance :)