### PR TITLE
Support MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,13 @@ This is a simple shell script that can be used to ignore files from dropbox usin
 
 ### Basic Installation
 
-dropboxignore is installed by running one of the following commands in your terminal. You can install this via the command-line with either curl, wget or another similar tool. `attr` and `git` package should be installed on your system, as well as the `diffutils` and `grep` packages for macOS.
+dropboxignore is installed by running one of the following commands in your terminal. You can install this via the command-line with either curl, wget or another similar tool. `attr` and `git` should be installed on your system, as well as Homebrew if you are on macOS.
 
 | Mathod | Command                                                                                                       |
 |--------|---------------------------------------------------------------------------------------------------------------|
 | curl   | `sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`  |
 | wget   | `sudo sh -c "$(wget -qO- https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`   |
 | fetch  | `sudo sh -c "$(fetch -o - https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`  |
-
-### Installation notes for MacOS
-- MacOS 10.8 or later is required
-- To install required packages, you will need Homebrew. Run `brew install diffutils` and `brew install grep` in addition to the installation command above.
 
 ### Snap Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a simple shell script that can be used to ignore files from dropbox usin
 
 ### Basic Installation
 
-dropboxignore is installed by running one of the following commands in your terminal. You can install this via the command-line with either curl, wget or another similar tool. `attr` and `git` package should be installed on your system.
+dropboxignore is installed by running one of the following commands in your terminal. You can install this via the command-line with either curl, wget or another similar tool. `attr` and `git` package should be installed on your system, as well as the `diffutils` and `grep` packages for macOS.
 
 | Mathod | Command                                                                                                       |
 |--------|---------------------------------------------------------------------------------------------------------------|
@@ -40,6 +40,9 @@ dropboxignore is installed by running one of the following commands in your term
 | wget   | `sudo sh -c "$(wget -qO- https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`   |
 | fetch  | `sudo sh -c "$(fetch -o - https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"`  |
 
+### Installation notes for MacOS
+- MacOS 10.8 or later is required
+- To install required packages, you will need Homebrew. Run `brew install diffutils` and `brew install grep` in addition to the installation command above.
 
 ### Snap Installation
 

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -18,6 +18,8 @@ TOTAL_N_REVERTED_FILES=0
 TOTAL_N_GENERATED_FILES=0
 BASE_FOLDER="$PWD"
 FILE_ATTR_NAME="com.dropbox.ignored"
+[[ $MACHINE = "Darwin" ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
+[[ $MACHINE = "Darwin" ]] && DIFF_CMD="/usr/local/bin/diff" || DIFF_CMD="diff"
 
 DEFAULT="\e[0m"
 GREEN="\e[32m"
@@ -290,7 +292,7 @@ EOF
 #   Update status.
 #######################################
 update_dropboxignore_file() {
-  diff_content=$(diff --new-line-format="" --unchanged-line-format="" --ignore-blank-lines --ignore-tab-expansion --ignore-space-change --ignore-trailing-space -I "# [Automatically|-]" "${1}" "${2}")
+  diff_content=$("$DIFF_CMD" --new-line-format="" --unchanged-line-format="" --ignore-blank-lines --ignore-tab-expansion --ignore-space-change --ignore-trailing-space -I "# [Automatically|-]" "${1}" "${2}")
   if [ -n "$diff_content" ]; then
     tee -a "$2" >/dev/null <<EOF
 # Automatically updated .dropboxignore file at "$(date)"
@@ -333,7 +335,7 @@ update_dropboxignore_files() {
 generate_dropboxignore_files() {
   find_gitignore_files "$1"
   for gitignore_file in $GITIGNORE_FILES; do
-    if grep -q -P '^\s*!' "$gitignore_file"; then
+    if "$GREP_CMD" -q -P '^\s*!' "$gitignore_file"; then
       echo -e "$YELLOW$(get_relative_path "$gitignore_file" "$BASE_FOLDER") contains exception patterns, will be ignored"
       continue
     fi
@@ -424,7 +426,7 @@ ignore_files() {
         for dropboxignore_file in $DROPBOX_IGNORE_FILES; do
           file_total_results=0
           # shellcheck disable=SC2013
-          if grep -q -P '^\s*!' "$dropboxignore_file"; then
+          if "$GREP_CMD" -q -P '^\s*!' "$dropboxignore_file"; then
             echo -e "$YELLOW$(get_relative_path "$dropboxignore_file" "$BASE_FOLDER") contains exception patterns, will be ignored"
             continue
           fi
@@ -438,7 +440,7 @@ ignore_files() {
               ((n_results++))
             done < <(find "$(dirname "$dropboxignore_file")/$subdir" -name "$pattern")
             file_total_results=$((file_total_results + n_results))
-          done < <(grep -v -P '^\s*$|^\s*\#|^\s*!' "$dropboxignore_file")
+          done < <("$GREP_CMD" -v -P '^\s*$|^\s*\#|^\s*!' "$dropboxignore_file")
           log_debug "Matched files because of '$(get_relative_path "$dropboxignore_file" "$BASE_FOLDER")': $file_total_results"
         done
     fi

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -19,7 +19,7 @@ TOTAL_N_GENERATED_FILES=0
 BASE_FOLDER="$PWD"
 FILE_ATTR_NAME="com.dropbox.ignored"
 [[ $MACHINE == Darwin ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
-[[ $MACHINE == Darwin ]] && DIFF_CMD="$(brew --prefix)/diff" || DIFF_CMD="diff"
+[[ $MACHINE == Darwin ]] && DIFF_CMD="$(brew --prefix)/bin/diff" || DIFF_CMD="diff"
 
 DEFAULT="\e[0m"
 GREEN="\e[32m"

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -19,7 +19,7 @@ TOTAL_N_GENERATED_FILES=0
 BASE_FOLDER="$PWD"
 FILE_ATTR_NAME="com.dropbox.ignored"
 [[ $MACHINE == Darwin ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
-[[ $MACHINE == Darwin ]] && DIFF_CMD="/usr/local/bin/diff" || DIFF_CMD="diff"
+[[ $MACHINE == Darwin ]] && DIFF_CMD="$(brew --prefix)/diff" || DIFF_CMD="diff"
 
 DEFAULT="\e[0m"
 GREEN="\e[32m"

--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -18,8 +18,8 @@ TOTAL_N_REVERTED_FILES=0
 TOTAL_N_GENERATED_FILES=0
 BASE_FOLDER="$PWD"
 FILE_ATTR_NAME="com.dropbox.ignored"
-[[ $MACHINE = "Darwin" ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
-[[ $MACHINE = "Darwin" ]] && DIFF_CMD="/usr/local/bin/diff" || DIFF_CMD="diff"
+[[ $MACHINE == Darwin ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
+[[ $MACHINE == Darwin ]] && DIFF_CMD="/usr/local/bin/diff" || DIFF_CMD="diff"
 
 DEFAULT="\e[0m"
 GREEN="\e[32m"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Below you will all the available installation options. dropboxignore is currently available only for Mac OS and Linux systems.
+Below you will all the available installation options. dropboxignore is currently available only for macOS and Linux systems.  For macOS, Homebrew is required.
 
 ## Basic Installation
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -3,8 +3,8 @@
 # First install additional dependencies if on macOS
 MACHINE="$(uname -s)"
 if [ "$MACHINE" == Darwin ]; then
-  HOMEBREW_NO_AUTO_UPDATE=1 brew install diffutils
-  HOMEBREW_NO_AUTO_UPDATE=1 brew install grep
+  sudo -u "$SUDO_USER" HOMEBREW_NO_AUTO_UPDATE=1 brew install diffutils
+  sudo -u "$SUDO_USER" HOMEBREW_NO_AUTO_UPDATE=1 brew install grep
 fi
 
 # Install dropboxignore command

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# First install additional dependencies if on macOS
+MACHINE="$(uname -s)"
+if [ "$MACHINE" == Darwin ]; then
+  HOMEBREW_NO_AUTO_UPDATE=1 brew install diffutils
+  HOMEBREW_NO_AUTO_UPDATE=1 brew install grep
+fi
+
+# Install dropboxignore command
 rm -rf /usr/local/bin/dropboxignore
 git clone https://github.com/sp1thas/dropboxignore.git
 make -C dropboxignore install


### PR DESCRIPTION
This issue fixes #23, a problem apparently appearing on MacOS 10.8 and above. The diff command has been changed as well on Mac. Added instructions on how to install the matching `grep` and `diff` commands, and modified the code to use them.