### PR TITLE
Parentheses for python `print`

### DIFF
--- a/bin/dropboxignore.sh
+++ b/bin/dropboxignore.sh
@@ -198,7 +198,7 @@ get_relative_path() {
   if command -v realpath &>/dev/null; then
     realpath --relative-to="${2-$PWD}" "$1"
   else
-    python -c 'import os.path, sys;print os.path.relpath(sys.argv[1],sys.argv[2])' "$1" "${2-$PWD}"
+    python -c 'import os.path, sys;print(os.path.relpath(sys.argv[1],sys.argv[2]))' "$1" "${2-$PWD}"
   fi
 }
 
@@ -211,7 +211,7 @@ get_absolute_path() {
   if command -v realpath &>/dev/null; then
     realpath "$1"
   else
-    python -c 'import os.path, sys;print os.path.abspath(sys.argv[1])' "$1"
+    python -c 'import os.path, sys;print(os.path.abspath(sys.argv[1]))' "$1"
   fi
 }
 


### PR DESCRIPTION
I'm on an M1 Mac, running Python 3.9.12.

Running `dropboxignore genupi .` in the root of a project yielded me this:

```
dropboxignore genupi .
  File "<string>", line 1
    import os.path, sys;print os.path.abspath(sys.argv[1])
                              ^
SyntaxError: invalid syntax
  File "<string>", line 1
    import os.path, sys;print os.path.relpath(sys.argv[1],sys.argv[2])
                              ^
SyntaxError: invalid syntax
Wed Aug 31 17:47:09 EDT 2022 \e[32m [  INFO ] Created file:  \e[0m \e[0m
\e[33mTotal number of generated files: 1 \e[0m
  File "<string>", line 1
    import os.path, sys;print os.path.relpath(sys.argv[1],sys.argv[2])
                              ^
SyntaxError: invalid syntax
\e[34mTotal number of ignored files: 0 \e[0m
Total number of ignored folders: 0 \e[0m
```

I'm not a Python dev myself but I fired up the interpreter and imported `os.path` and tried to print it with this syntax. It seems to be looking for parentheses. 

```
>>> import os.path, sys;print os.path
  File "<stdin>", line 1
    import os.path, sys;print os.path
                              ^
SyntaxError: invalid syntax
```

Was able to get the command working after `sudo make install`ing with parens in the two lines where `os.path` is imported.

Not sure if this is a syntax issue due to Python version, but various web linters showed a syntax error.