### PR TITLE
Matrix builds for tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install os dependencies
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
           if [ "${{ runner.os }}" = "Linux" ]; then
             sudo apt update && sudo apt install attr kcov
           else
-            brew install kcov
+            brew install kcov diffutils grep
           fi
       - name: Install bats-core
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Testing
 
 on:
   push:
-    # branches: [ master ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
       - '**/mkdocs.yml'
@@ -43,10 +43,10 @@ jobs:
         run: |
           kcov --include-path=bin/dropboxignore.sh /tmp/coverage bats tests/*.bats
           cp $(find /tmp/coverage -type f -name 'cobertura.xml') coverage.xml
-      # - uses: codecov/codecov-action@v2
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     fail_ci_if_error: true
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,17 +2,31 @@ name: Testing
 
 on:
   push:
-    branches: [ master ]
+    # branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - '**/mkdocs.yml'
+      - '**/shellcheck.yml'
+      - '**/stats.yml'
   pull_request:
     branches: [ master ]
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install os dependencies
-        run: sudo apt update && sudo apt install attr kcov
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            sudo apt update && sudo apt install attr kcov
+          else
+            brew install kcov
+          fi
       - name: Install bats-core
         run: |
           git clone https://github.com/bats-core/bats-core.git
@@ -29,17 +43,26 @@ jobs:
         run: |
           kcov --include-path=bin/dropboxignore.sh /tmp/coverage bats tests/*.bats
           cp $(find /tmp/coverage -type f -name 'cobertura.xml') coverage.xml
-      - uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-  integration:
-    runs-on: ubuntu-latest
+      # - uses: codecov/codecov-action@v2
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     fail_ci_if_error: true
 
+  integration:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v2
       - name: Install os dependencies
-        run: sudo apt update && sudo apt install wget curl
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            sudo apt update && sudo apt install wget curl
+          else
+            brew install wget curl
+          fi
       - name: Install using wget
         run: |
           sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/sp1thas/dropboxignore/master/utils/install.sh)"


### PR DESCRIPTION
Hi @sp1thas 

### Added:
- Matrix for unit test job

### Changed:
- Added workflow yaml files to `paths-ignore` in `testing.yml` to avoid run build when it does not make sense
- Updated `actions/checkout@v2` to `actions/checkout@v3` because old version has deprecated node12

Closes #28 

### Notes:
macOS tests will fail if you does't have GNU diff and GNU grep (`diffutils` and `grep` in brew) in your system.

Also, I found possible bug in `dropboxignore.sh` which I would recommend to resolve with additional check:

```bash
[[ $MACHINE == Darwin ]] && GREP_CMD="ggrep" || GREP_CMD="grep"
[[ $MACHINE == Darwin ]] && DIFF_CMD="$(brew --prefix)/bin/diff" || DIFF_CMD="diff"
```

If you does't have `ggrep` and `diff` in brew path – you'll see error which is not related to dropbox ignore features, it's error with third party software which you use inside script. It'll be more explicit if you'll check these tools before usage. With macOS default `grep` - tests also fails with error `/usr/local/bin/diff: unrecognized option `--ignore-trailing-space'`

For macOS users - I would recommend you to add all these prerequisites to Readme or other documentation.

