### PR TITLE
Remove /en/latest from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ for your case.
 
 ### Long story short
 
-[Here](https://dropboxignore.simakis.me/en/latest/getting-started/#long-story-short) you can find some of the most common cases
+[Here](https://dropboxignore.simakis.me/getting-started/#long-story-short) you can find some of the most common cases
 that dropboxignore could be useful.
 
 ## CLI
 
-[Here](https://dropboxignore.simakis.me/en/latest/cli/?utm=gh) you will find extensive documentation about the dropboxignore command line
+[Here](https://dropboxignore.simakis.me/cli/?utm=gh) you will find extensive documentation about the dropboxignore command line
 interface.
 
 ## How to contribute


### PR DESCRIPTION
Remove `/en/latest` from URLs to the documentation, as they result in 404 Not Found.