### PR TITLE
Run the unit job on macos-12

### DIFF
--- a/.github/workflows/shell-testing.yml
+++ b/.github/workflows/shell-testing.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-22.04, macos-12 ]
     steps:
       - uses: actions/checkout@v3
       - name: Install os dependencies


### PR DESCRIPTION
Add `macos-12` to the build matrix of the `unit` job. This hopefully reveals the problem reported in #57.